### PR TITLE
changing the go version to latest 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensds/crystal
 
-go 1.17
+go 1.22.0
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.3


### PR DESCRIPTION
* changing the go version to latest
* previous version was 1.17

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature
> /kind bug fix
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:

root@pravin:~/gopath/src/github.com/sodafoundation/crystal# make all
mkdir -p  /root/gopath/src/github.com/sodafoundation/crystal/build
CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s -extldflags "-static"' -o /root/gopath/src/github.com/sodafoundation/crystal/build/api github.com/opensds/crystal/api/cmd
go: downloading go1.22.0 (linux/amd64)

CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s -extldflags "-static"' -o /root/gopath/src/github.com/sodafoundation/crystal/build/aksk github.com/opensds/crystal/aksk/cmd
CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s -extldflags "-static"' -o /root/gopath/src/github.com/sodafoundation/crystal/build/backend github.com/opensds/crystal/backend/cmd

CGO_ENABLED=1 GOOS=linux go build -ldflags '-w -s -extldflags "-dynamic"' -o /root/gopath/src/github.com/sodafoundation/crystal/build/s3 github.com/opensds/crystal/s3/cmd
CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s -extldflags "-static"' -o /root/gopath/src/github.com/sodafoundation/crystal/build/metadata github.com/opensds/crystal/metadata/cmd

-->

**Special notes for your reviewer**:
